### PR TITLE
infrastructure: split settings module depending on the stage of devel…

### DIFF
--- a/Metrica_project/settings/settings_base.py
+++ b/Metrica_project/settings/settings_base.py
@@ -12,13 +12,12 @@ https://docs.djangoproject.com/en/3.1/ref/settings/
 
 from pathlib import Path
 import os
-import sys
 from dotenv import load_dotenv, find_dotenv
 
 load_dotenv(find_dotenv())
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
-BASE_DIR = Path(__file__).resolve().parent.parent
+BASE_DIR = Path(__file__).resolve().parent.parent.parent
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/3.1/howto/deployment/checklist/
@@ -27,14 +26,11 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 SECRET_KEY = os.getenv('DJANGO_KEY')
 
 # SECURITY WARNING: don't run with debug turned on in production!
-# DEBUG = True
-DEBUG = bool(os.getenv('DEBUG_MODE'))
+DEBUG = False
 
 ALLOWED_HOSTS = [
     'a-metrica.herokuapp.com',
     '127.0.0.1',
-    os.getenv('ALLOWED_HOST_PGROK'),
-    'testserver',
 ]
 
 # Application definition
@@ -51,7 +47,6 @@ INSTALLED_APPS = [
     'games',
     'bootstrap4',
     'anymail',
-    'debug_toolbar',
     'django_filters',
 ]
 
@@ -105,34 +100,10 @@ WSGI_APPLICATION = 'Metrica_project.wsgi.application'
 
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.postgresql',
-        'NAME': os.getenv('DB_NAME_HEROKU'),
-        'USER': os.getenv('DB_USER_HEROKU'),
-        'PASSWORD': os.getenv('DB_PASSWORD_HEROKU'),
-        'HOST': os.getenv('DB_HOST_HEROKU'),
-        'PORT': '5432',
-        'TEST': {
-            'NAME': os.getenv('TEST_DB'),
-            'USER': os.getenv('DB_USER')
-        }
-    }
-}
-# if testing (sys.argv contain 'test') db settings set to
-# 'local db' sqlite3 and django connect to it to
-# create tables for testings purpose
-if 'test' in sys.argv:
-    DATABASES['default'] = {
         'ENGINE': 'django.db.backends.sqlite3',
         'NAME': BASE_DIR / 'db.sqlite3',
     }
-
-# DATABASES = {
-#     'default': {
-#         'ENGINE': 'django.db.backends.sqlite3',
-#         'NAME': BASE_DIR / 'db.sqlite3',
-#     }
-# }
-
+}
 
 # Password validation
 # https://docs.djangoproject.com/en/3.1/ref/settings/#auth-password-validators
@@ -157,7 +128,7 @@ AUTH_USER_MODEL = 'users.CustomUser'
 # Internationalization
 # https://docs.djangoproject.com/en/3.1/topics/i18n/
 
-LANGUAGE_CODE = 'en-us'
+LANGUAGE_CODE = 'ru-ru'
 
 TIME_ZONE = 'UTC'
 
@@ -185,16 +156,13 @@ ANYMAIL = {
     "MAILGUN_API_KEY": os.getenv('MAILGUN_API_KEY'),
     "MAILGUN_SENDER_DOMAIN": os.getenv('MAILGUN_DOMAIN'),  # your Mailgun domain, if needed
 }
+
 EMAIL_BACKEND = "anymail.backends.mailgun.EmailBackend"  # or sendgrid.EmailBackend, or...
 DEFAULT_FROM_EMAIL = os.getenv('DEFAULT_FROM_EMAIL')  # if you don't already have this in settings
 SERVER_EMAIL = os.getenv('SERVER_EMAIL')  # ditto (default from-email for Django errors)
 
 STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
 
-# Debug toolbar will be available for requests from this IPs
-INTERNAL_IPS = [
-    '127.0.0.1',
-    ]
 
 LOGGING = {
     "version": 1,

--- a/Metrica_project/settings/settings_dev.py
+++ b/Metrica_project/settings/settings_dev.py
@@ -1,0 +1,50 @@
+from .settings_base import *
+import sys
+
+DEBUG = True
+
+
+ALLOWED_HOSTS = [
+    os.getenv('ALLOWED_HOST_PGROK'),
+    'testserver',
+    '127.0.0.1',
+]
+
+INSTALLED_APPS += [
+    'debug_toolbar',
+]
+
+# Debug toolbar will be available for requests from this IPs
+INTERNAL_IPS = [
+    '127.0.0.1',
+    ]
+
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql',
+        'NAME': os.getenv('DB_NAME'),
+        'USER': os.getenv('DB_USER'),
+        'PASSWORD': os.getenv('DB_PASSWORD'),
+        'HOST': os.getenv('DB_HOST'),
+        'PORT': '5432',
+        'TEST': {
+            'NAME': os.getenv('TEST_DB'),
+            'USER': os.getenv('DB_USER')
+        }
+    }
+}
+
+# if testing (sys.argv contain 'test') db settings set to
+# 'local db' sqlite3 and django connect to it to
+# create tables for testings purpose
+if 'test' in sys.argv:
+    DATABASES['default'] = {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': BASE_DIR / 'db.sqlite3',
+    }
+
+# Debug toolbar will be available for requests from this IPs
+INTERNAL_IPS = [
+    '127.0.0.1',
+    ]

--- a/Metrica_project/settings/settings_prod.py
+++ b/Metrica_project/settings/settings_prod.py
@@ -1,0 +1,17 @@
+from .settings_base import *
+
+
+ALLOWED_HOSTS = [
+    'a-metrica.herokuapp.com',
+    ]
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql',
+        'NAME': os.getenv('DB_NAME_HEROKU'),
+        'USER': os.getenv('DB_USER_HEROKU'),
+        'PASSWORD': os.getenv('DB_PASSWORD_HEROKU'),
+        'HOST': os.getenv('DB_HOST_HEROKU'),
+        'PORT': '5432',
+    }
+}

--- a/Metrica_project/wsgi.py
+++ b/Metrica_project/wsgi.py
@@ -11,6 +11,6 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'Metrica_project.settings')
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'Metrica_project.settings.settings_prod')
 
 application = get_wsgi_application()

--- a/manage.py
+++ b/manage.py
@@ -6,7 +6,7 @@ import sys
 
 def main():
     """Run administrative tasks."""
-    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'Metrica_project.settings')
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'Metrica_project.settings.settings_prod')
     try:
         from django.core.management import execute_from_command_line
     except ImportError as exc:


### PR DESCRIPTION
Best practice. Разделение настроек на разные модули в зависимости от этапа разработки. Подключение нужного модуля настроек осуществляется путем установки переменной окружения DJANGO_SETTINGS_MODULE либо опцией командной строки --settings=<dot><separetade><path><to><settings><module>