### PR TITLE
N+1 query fix/admin panel

### DIFF
--- a/games/admin.py
+++ b/games/admin.py
@@ -1,6 +1,17 @@
 from django.contrib import admin
 from .models import Games, GameSession, GameScores
 
+
+class CustomGameScoresAdmin(admin.ModelAdmin):
+    model = GameScores
+    list_select_related = ("user", "game_session", "game_session__game")
+
+
+class CustomGameSessionAdmin(admin.ModelAdmin):
+    model = GameSession
+    list_select_related = ("game",)
+
+
 admin.site.register(Games)
-admin.site.register(GameSession)
-admin.site.register(GameScores)
+admin.site.register(GameSession, CustomGameSessionAdmin)
+admin.site.register(GameScores, CustomGameScoresAdmin)

--- a/games/models.py
+++ b/games/models.py
@@ -23,7 +23,7 @@ class GameSession(models.Model):
     game = models.ForeignKey(Games, on_delete=models.CASCADE, default='default_game', related_name='sessions')
     created_at = models.DateTimeField()
 
-    class Meta():
+    class Meta:
         ordering = ['-created_at']
 
     def __str__(self):

--- a/users/models.py
+++ b/users/models.py
@@ -8,7 +8,7 @@ from django.urls import reverse_lazy
 class CustomUser(AbstractUser):
     avatar = models.ImageField(upload_to='uploads/%Y/%m/%d/', null=True, blank=True)
 
-    class Meta():
+    class Meta:
         ordering = ["username"]
 
     def __str__(self):


### PR DESCRIPTION
В админке проблема N+1 разрешена путем кастомизации admin.ModelAdmin и переопределения атрибута list_select_related с необходимыми related (FK) полями 