### PR TITLE
Fix/user registration

### DIFF
--- a/users/templates/user_update_from_bot.html
+++ b/users/templates/user_update_from_bot.html
@@ -2,7 +2,7 @@
 {% load bootstrap4 %}
 
 {% block content %}
-    <form method="POST" action="{% url 'users:reg_cont' object.id %}">
+    <form method="POST" enctype="multipart/form-data" action="{% url 'users:reg_cont' object.id %}">
         {% csrf_token %}
         {% bootstrap_form form %}
         <div class="form-group">

--- a/users/views.py
+++ b/users/views.py
@@ -117,7 +117,7 @@ class UsersCreateView(CreateView):
 
 class UsersUpdateView(LoginRequiredMixin, UpdateView):
     model = users.models.CustomUser
-    form_class = CustomUserUpdateForm
+    form_class = CustomUserCreationForm
     template_name = 'user_update.html'
     success_url = reverse_lazy('users:users_index')
     perm_denied_msg = 'Permission denied. Only owner can change profile'
@@ -165,7 +165,7 @@ class UserUpdateViewFromBot(UpdateView):
     Class view without @login_required and permissions check for "registration-through-bot" process
     """
     model = users.models.CustomUser
-    form_class = CustomUserUpdateForm
+    form_class = CustomUserCreationForm
     template_name = 'user_update_from_bot.html'
     success_url = reverse_lazy('index')
 
@@ -198,24 +198,6 @@ class ClaimCreateView(LoginRequiredMixin, CreateView):
     def form_valid(self, form):
         form.instance.claimer = self.request.user
         return super().form_valid(form)
-
-
-@csrf_exempt  # disable csrf protection for testing via Postman by using decorator
-def add_user_view(request):
-    if request.method == 'POST':
-        request_raw = request.body
-        request_json = json.loads(request_raw)
-        user = request_json['user']
-        new_user_pk = add_user_into_db_simple(user)
-
-    if request.method == 'GET':
-        user = request.GET.get('user')
-        new_user_pk = add_user_into_db_simple(user)
-
-    return HttpResponse(f"{site_root_url}{str(reverse_lazy('users:reg_cont', args=[new_user_pk]))}"
-    ) if new_user_pk else HttpResponse(
-        f"Вы уже зарегистрированы. Можете перейти на сайт по этой ссылке {request.build_absolute_uri(reverse_lazy('index'))}"
-    )
 
 
 @method_decorator(csrf_exempt, name='dispatch')


### PR DESCRIPTION
Поменял встроенную джанговскую форму для регистрации юзера. Т.к. у нас юзер заносится в БД по одной команде из телеги без генерации и заполнении html форм, а процесс обновления этих данных (email, avatar, password) - через форму,
чтобы не городить отдельный эндпоинт для смены пароля (т.к. юзер уже в бд, хоть и без пароля - джанга в своих встроенных классах рассматривает этот процесс как ОБНОВЛЕНИЕ пароля) или кастомизировать builtin классы - вместо формы обновления данных пользователя использую форму создания нового пользователя (к уже созданному пользователю). Это дает возможность из одной формы задать И пароль для юзера